### PR TITLE
Hl re render all upon add or delete friend

### DIFF
--- a/src/scripts/Nutshell.js
+++ b/src/scripts/Nutshell.js
@@ -28,12 +28,12 @@ export const Nutshell = () => {
         renderArticleButton()
         getTasks()
         useTasks()
-        ArticleListComponent()
         MessageList()
         MessageForm()
         getFriends()
         .then(friendsList)
         .then(EventList)
+        .then(ArticleListComponent)
         
 
     } else {

--- a/src/scripts/articles/ArticleDataProvider.js
+++ b/src/scripts/articles/ArticleDataProvider.js
@@ -1,6 +1,7 @@
 //J.Kaset provides, fetches, saves, deletes all data about articles
 import {allFriendsURL} from "../friends/FriendsDataProvider.js"
 
+const eventHub = document.querySelector(".container")
 let articles = []
 
 

--- a/src/scripts/articles/ArticleDataProvider.js
+++ b/src/scripts/articles/ArticleDataProvider.js
@@ -9,8 +9,8 @@ export const useArticles = () => {
 };
 
 export const getArticles = () => {
-    return fetch(`http://localhost:8088/articles?_expand=user`)
-    //(`http://localhost:8088/articles?${allFriendsURL()}&_expand=user`)
+    return fetch(`http://localhost:8088/articles?${allFriendsURL()}&_expand=user`)
+    //(`http://localhost:8088/articles?${allFriendsURL()}&_expand=user`)(`http://localhost:8088/articles?_expand=user`)
     .then((response) => response.json())
     .then((parsedArticles) => {
         //console.log(`http://localhost:8088/articles?${allFriendsURL()}&_expand=user`)

--- a/src/scripts/friends/AddFriend.js
+++ b/src/scripts/friends/AddFriend.js
@@ -1,9 +1,11 @@
 // Heath Lester
 // Listens for "saveFriend"; parses through users; adds relationship; re-renders FriendsList.
 
-
+import { ArticleListComponent } from "../articles/ArticleList.js"
+import { EventList } from "../events/EventList.js"
+import { MessageList } from "../messages/MessageList.js"
 import { useUsers } from "../UsersDataProvider.js"
-import { addFriend } from "./FriendsDataProvider.js"
+import { addFriend, getFriends } from "./FriendsDataProvider.js"
 import { friendsList } from "./FriendsList.js"
 
 
@@ -27,7 +29,11 @@ eventHub.addEventListener("addSavedFriend", friendObj => {
         }
 
         addFriend(newRelationship)
+            .then(getFriends)
             .then(friendsList)
+            .then(MessageList)
+            .then(EventList)
+            .then(ArticleListComponent)
     } else {
         alert("User not found!")
     }

--- a/src/scripts/friends/DeleteFriend.js
+++ b/src/scripts/friends/DeleteFriend.js
@@ -2,7 +2,10 @@
 // Heath Lester
 // Matches deleting friends id to a relationship and deletes if from the /friends endpoint.
 
-import { useFriends, deleteFriend } from "./FriendsDataProvider.js"
+import { ArticleListComponent } from "../articles/ArticleList.js"
+import { EventList } from "../events/EventList.js"
+import { MessageList } from "../messages/MessageList.js"
+import { useFriends, deleteFriend, getFriends } from "./FriendsDataProvider.js"
 import { friendsList } from "./FriendsList.js"
 
 
@@ -20,5 +23,9 @@ eventHub.addEventListener("deleteFriend", unwantedFriend => {
     const userRelationships = allRelationships.filter(relationship => relationship.userId === currentUserId)
     const doomedRelationship = userRelationships.find(relationship => relationship.followeeId === unwantedFriend.detail.friendId)
     deleteFriend(doomedRelationship)
+        .then(getFriends)
         .then(friendsList)
+        .then(MessageList)
+        .then(EventList)
+        .then(ArticleListComponent)
 })


### PR DESCRIPTION
# Description
- Moved ArticleListComponent( ) initial render after getFriends( ).
- Modified ArticleDataProvider.js to GET all users and user's friend's articles.
- Appended List functions to deleteFriend and addFriend.
Fixes #70 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
```get fetch --all```
```get checkout hl-re-render-all-upon-add-or-delete-friend```
```serve```
1. Make sure there are multiple Articles and Events for different Users
2. Add Friend (Articles, Events, and Friends should populate WITHOUT refreshing)
3. Delete Friend (same but de-populate)
**You should not see articles that do not have a relationship to the user OTHER than the user itself.**

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
